### PR TITLE
Using realm name instead of id in addUser JobQueue

### DIFF
--- a/src/main/java/dev/suvera/keycloak/scim2/storage/storage/SkssStorageProvider.java
+++ b/src/main/java/dev/suvera/keycloak/scim2/storage/storage/SkssStorageProvider.java
@@ -91,7 +91,7 @@ public class SkssStorageProvider implements UserStorageProvider,
 
         entity.setId(KeycloakModelUtils.generateId());
         entity.setAction("userCreate");
-        entity.setRealmId(realmModel.getId());
+        entity.setRealmId(realmModel.getName());
 
         entity.setComponentId(componentModel.getId());
         entity.setUsername(username);


### PR DESCRIPTION
As discussed in #4 might be related to the old Keycloak version I'm using, this needs further testing in more recent versions.